### PR TITLE
Fix critical flaw in MiniMessage documentation

### DIFF
--- a/source/minimessage.rst
+++ b/source/minimessage.rst
@@ -70,7 +70,7 @@ Adding the repository
       .. code:: groovy
 
          dependencies {
-            implementation 'net.kyori:adventure-text-minimessage:.0.0-SNAPSHOT'
+            implementation 'net.kyori:adventure-text-minimessage:3.0.0-SNAPSHOT'
          }
 
 


### PR DESCRIPTION
*Literally unusable, how could such a careless mistake slip through*