### PR TITLE
Add BOM to usage guidelines.

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -88,7 +88,7 @@ First, add the repository:
                <dependency>
                   <groupId>net.kyori</groupId>
                   <artifactId>adventure-bom</artifactId>
-                  <version>4.2.0</version>
+                  <version>4.5.1</version>
                   <type>pom</type>
                   <scope>import</scope>
                </dependency>
@@ -104,12 +104,12 @@ First, add the repository:
       .. code:: groovy
 
          dependencies {
-            implementation platform('net.kyori:adventure-bom:4.2.0')
+            implementation(platform("net.kyori:adventure-bom:4.5.1"))
              // Use dependency defined in BOM.
              // Version is not needed, because the version
              // defined in the BOM is a dependency constraint
              // that is used.
-            implementation 'net.kyori:adventure-api'
+            implementation("net.kyori:adventure-api")
          }
 
 
@@ -118,7 +118,7 @@ First, add the repository:
       .. code:: kotlin
 
          dependencies {
-            implementation(platform("net.kyori:adventure-bom:4.2.0"))
+            implementation(platform("net.kyori:adventure-bom:4.5.1"))
             implementation("net.kyori:adventure-api")
          }
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -82,16 +82,17 @@ First, add the repository:
    .. group-tab:: Maven
 
       .. code:: xml
+      
          <dependencyManagement>
-             <dependencies>
-                 <dependency>
-                     <groupId>net.kyori</groupId>
-                     <artifactId>adventure-bom</artifactId>
-                     <version>4.2.0</version>
-                     <type>pom</type>
-                     <scope>import</scope>
-                 </dependency>
-             </dependencies>
+            <dependencies>
+               <dependency>
+                  <groupId>net.kyori</groupId>
+                  <artifactId>adventure-bom</artifactId>
+                  <version>4.2.0</version>
+                  <type>pom</type>
+                  <scope>import</scope>
+               </dependency>
+            </dependencies>
          </dependencyManagement>
          <dependency>
             <groupId>net.kyori</groupId>

--- a/source/index.rst
+++ b/source/index.rst
@@ -82,11 +82,20 @@ First, add the repository:
    .. group-tab:: Maven
 
       .. code:: xml
-
+         <dependencyManagement>
+             <dependencies>
+                 <dependency>
+                     <groupId>net.kyori</groupId>
+                     <artifactId>adventure-bom</artifactId>
+                     <version>4.2.0</version>
+                     <type>pom</type>
+                     <scope>import</scope>
+                 </dependency>
+             </dependencies>
+         </dependencyManagement>
          <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-api</artifactId>
-            <version>4.2.0-SNAPSHOT</version>
          </dependency>
    
    .. group-tab:: Gradle (Groovy)
@@ -94,7 +103,12 @@ First, add the repository:
       .. code:: groovy
 
          dependencies {
-            implementation 'net.kyori:adventure-api:4.2.0-SNAPSHOT'
+            implementation platform('net.kyori:adventure-bom:4.2.0')
+             // Use dependency defined in BOM.
+             // Version is not needed, because the version
+             // defined in the BOM is a dependency constraint
+             // that is used.
+            implementation 'net.kyori:adventure-api'
          }
 
 
@@ -103,7 +117,8 @@ First, add the repository:
       .. code:: kotlin
 
          dependencies {
-            implementation("net.kyori:adventure-api:4.2.0-SNAPSHOT")
+            implementation(platform("net.kyori:adventure-bom:4.2.0"))
+            implementation("net.kyori:adventure-api")
          }
 
 Indices and tables


### PR DESCRIPTION
Adjust usage guidelines to recommend using a Bill of Materials to assist keeping dependencies in sync for a dependent project.