### PR TITLE
Added Krypton to natives

### DIFF
--- a/source/platform/native.rst
+++ b/source/platform/native.rst
@@ -17,3 +17,5 @@ The following software provide native support for Adventure.
 +----------+------------------+-----------------------------------------------------------------------------------------------+
 | Minestom | Build 7494725    | For more information, see the `Minestom Wiki <https://wiki.minestom.com/feature/adventure>`_. |
 +----------+------------------+-----------------------------------------------------------------------------------------------+
+| Krypton  | 0.9 (build 13)   | Messages, titles, action bars and player list supported.                                      |
++----------+------------------+-----------------------------------------------------------------------------------------------+


### PR DESCRIPTION
I highly doubt this one's going to get anything but closed, as I'm aware that my platform isn't all that popular (I think 20 stars is a lot, but in the grand scheme of things, not really), but I thought it was worth a try anyway, because why not ¯\_(ツ)_/¯

Krypton's had support for Adventure since 0.9 (apparently, had to find that lol), and we're currently on 0.18.2, so it's been a while. It supports it all the way down to the network level, as some packet constructors take components.

Krypton is my Minecraft server written in Kotlin, it can be found [here](https://github.com/KryptonMC/Krypton).

Feel free to oust me with pitch forks in hand if I somehow screwed something up