### PR TITLE
Update to 4.8.0, plus some other minor tweaks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sphinx-autobuild # for live reload in development
 sphinx-rtd-theme
 sphinx-tabs
 rstcheck # format checks
+Sphinx-Substitution-Extensions # for replacements in code blocks/etc

--- a/source/audiences.rst
+++ b/source/audiences.rst
@@ -25,3 +25,19 @@ for you.
 
 Most users using will primarily use this API to show content created by other parts
 of the API.
+
+Pointers
+^^^^^^^^
+
+Audiences can also provide arbitrary information, such as display name or UUID.
+This is done using the pointer system.
+
+Examples:
+
+.. code:: java
+
+  // get the uuid from an audience member, returning an Optional<UUID>
+  audience.get(Identity.UUID);
+
+  // get the display name, returning a default
+  audience.getOrDefault(Identity.DISPLAY_NAME, Component.text("no display name!"));

--- a/source/book.rst
+++ b/source/book.rst
@@ -16,8 +16,8 @@ Books are composed of:
 
     //Create and open a book about cats for the target audience
     public void openMyBook(final @NonNull Audience target){
-        Component bookTitle = TextComponent.text("Encyclopedia of cats");
-        Component bookAuthor = TextComponent.text("kashike");
+        Component bookTitle = Component.text("Encyclopedia of cats");
+        Component bookAuthor = Component.text("kashike");
         Collection<Component> bookPages = Cats.getCatKnowledge();
 
         Book myBook = Book.book(bookTitle, bookAuthor, bookPages);

--- a/source/conf.py
+++ b/source/conf.py
@@ -24,7 +24,7 @@ copyright = '2020-2021, KyoriPowered'
 author = 'KyoriPowered'
 
 # The short X.Y version
-version = '4.7.0'
+version = '4.8.0'
 
 # The full version, including alpha/beta/rc tags
 release = version
@@ -38,7 +38,9 @@ rst_prolog = """
     The Adventure docs are currently a **work in progress**. Some areas may have limited coverage or may not be entirely up to date.
     Feel free to join our discord at `<https://discord.gg/MMfhJ8F>`_ if you have any questions.
 
-"""
+.. |version| replace:: {version}
+
+""".format(version = version)
 
 
 
@@ -49,7 +51,9 @@ rst_prolog = """
 # ones.
 extensions = [
   'sphinx_rtd_theme',
-  'sphinx_tabs.tabs'
+  'sphinx_tabs.tabs',
+  'sphinx-prompt',
+  'sphinx_substitution_extensions'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -1,0 +1,91 @@
+===============
+Getting Started
+===============
+
+To use Adventure in your project, you will need to add the following dependency and repository (if using Gradle):
+
+.. tabs::
+
+   .. group-tab:: Maven
+
+      .. code-block:: xml
+        :substitutions:
+
+         <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-api</artifactId>
+            <version>|version|</version>
+         </dependency>
+
+   .. group-tab:: Gradle (Groovy)
+
+      .. code-block:: groovy
+        :substitutions:
+
+         repositories {
+           mavenCentral()
+         }
+
+         dependencies {
+            implementation "net.kyori:adventure-api:|version|"
+         }
+
+
+   .. group-tab:: Gradle (Kotlin)
+
+      .. code-block:: kotlin
+        :substitutions:
+
+         repositories {
+           mavenCentral()
+         }
+
+         dependencies {
+            implementation("net.kyori:adventure-api:|version|")
+         }
+
+Some platforms already use Adventure natively.
+In this case, you will not need to add Adventure as a dependency.
+To view the list of platforms that include Adventure, see :doc:`/platform/native`.
+
+To use Adventure with other platforms, you may wish to look at the platform-specific adapters.
+A list of platforms with supported adapters can be found at :doc:`/platform/index`.
+
+Using Snapshot Builds
+^^^^^^^^^^^^^^^^^^^^^
+
+To use snapshot builds, you will need to add the following repository:
+
+.. tabs::
+
+   .. group-tab:: Maven
+
+      .. code:: xml
+
+         <repositories>
+             <repository>
+                <id>sonatype-oss-snapshots</id>
+                <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+             </repository>
+         </repositories>
+
+   .. group-tab:: Gradle (Groovy)
+
+      .. code:: groovy
+
+         repositories {
+            maven {
+                name = "sonatype-oss-snapshots"
+                url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            }
+         }
+
+   .. group-tab:: Gradle (Kotlin)
+
+      .. code:: kotlin
+
+         repositories {
+            maven(url = "https://oss.sonatype.org/content/repositories/snapshots/") {
+                name = "sonatype-oss-snapshots"
+            }
+         }

--- a/source/index.rst
+++ b/source/index.rst
@@ -7,8 +7,15 @@ Adventure
    .. warning:: This documentation is for an **unreleased** version of 
       Adventure. Some information may not be up to date, and API is subject to change.
 
+Adventure is a library for server-controllable user interface elements in *Minecraft: Java Edition*.
+
+Table of Contents
+^^^^^^^^^^^^^^^^^
+
 .. toctree::
    :maxdepth: 2
+
+   getting-started
 
    audiences
    text
@@ -23,88 +30,6 @@ Adventure
    platform/index
 
    migration/index
-
-
-Adventure is a library for server-controllable user interface elements in *Minecraft: Java Edition*.
-
-
-Importing Adventure into your project
--------------------------------------
-
-First, add the repository:
-
-.. tabs::
-   
-   .. group-tab:: Maven
-
-      .. code:: xml
-
-         <repositories>
-             <!-- ... -->
-             <repository> <!-- for development builds -->
-                <id>sonatype-oss-snapshots</id>
-                <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-             </repository>
-             <!-- ... -->
-         </repositories>
-   
-   .. group-tab:: Gradle (Groovy)
-
-      .. code:: groovy
-
-         repositories {
-            // for development builds
-            maven {
-                name = "sonatype-oss-snapshots"
-                url = "https://oss.sonatype.org/content/repositories/snapshots/"
-            }
-            // for releases
-            mavenCentral()
-         }
-
-   .. group-tab:: Gradle (Kotlin)
-
-      .. code:: kotlin
-
-         repositories {
-            // for development builds
-            maven(url = "https://oss.sonatype.org/content/repositories/snapshots/") {
-                name = "sonatype-oss-snapshots"
-            }
-            // for releases
-            mavenCentral()
-         }
-
-   Declaring the dependency:
-
-.. tabs::
-   
-   .. group-tab:: Maven
-
-      .. code:: xml
-
-         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-api</artifactId>
-            <version>4.7.0</version>
-         </dependency>
-   
-   .. group-tab:: Gradle (Groovy)
-
-      .. code:: groovy
-
-         dependencies {
-            implementation "net.kyori:adventure-api:4.7.0"
-         }
-
-
-   .. group-tab:: Gradle (Kotlin)
-
-      .. code:: kotlin
-
-         dependencies {
-            implementation("net.kyori:adventure-api:4.7.0")
-         }
 
 Indices and tables
 ==================

--- a/source/sound.rst
+++ b/source/sound.rst
@@ -18,16 +18,35 @@ Sounds are composed of:
 
 .. code:: java
 
-  public void playMySound(final @NonNull Audience target) {
-    // Play a built-in sound at the target's location with standard volume and pitch
-    target.playSound(Sound.sound(Key.key("music_disc.13"), Sound.Source.MUSIC, 1f, 1f));
-    // Play a sound from our resource pack, with a higher pitch
-    target.playSound(Sound.sound(Key.key("adventure", "rawr"), Sound.Source.AMBIENT, 1f, 1.1f));
-  }
+  // Create a built-in sound using standard volume and pitch
+  Sound musicDisc = Sound.sound(Key.key("music_disc.13"), Sound.Source.MUSIC, 1f, 1f);
 
-.. sidebar:: Limitations
+  // Create a sound from our resource pack with a higher pitch
+  Sound myCustomSound = Sound.sound(Key.key("adventure", "rawr"), Sound.Source.AMBIENT, 1f, 1.1f);
 
-  The client can play multiple sounds at once, but as of version 1.16 is limited to 8 sounds playing at once.
+Playing a Sound
+^^^^^^^^^^^^^^^
+
+.. warning::
+
+  - The client can play multiple sounds at once, but as of version 1.16 is limited to 8 sounds playing at once.
+  - Due to `MC-138832 <https://bugs.mojang.com/browse/MC-138832>`_, the volume and pitch of sounds played with an emitter may be ignored.
+
+Once you've created a sound, they can be played to an audience using multiple methods:
+
+.. code:: java
+
+  // Play a sound at the location of the audience
+  audience.playSound(sound);
+
+  // Play a sound at a specific location
+  audience.playSound(sound, 100, 0, 150);
+
+  // Play a sound that follows the audience member
+  audience.playSound(sound, Sound.Emitter.self());
+
+  // Play a sound that follows another emitter (usually an entity)
+  audience.playSound(sound, someEntity);
 
 Stopping Sounds
 ^^^^^^^^^^^^^^^
@@ -44,6 +63,17 @@ A sound stop will stop the chosen sounds -- ranging from every sound the client 
     // Stop all sounds for the target
     target.stopSound(SoundStop.all());
   }
+
+Sound stops can be constructed using the methods in the example block above.
+Alternatively, they can be constructed directly from a sound.
+
+.. code:: java
+
+  // Get a sound stop that will stop a specific sound
+  mySound.asStop();
+
+  // Sounds can also be stopped directly using the stopSound method
+  audience.stopSound(mySound);
 
 Creating a custom sound
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR makes the following changes:

- Update to 4.8.0
  - Pointer documentation
  - New sound methods (emitter and stop changes)
- Provide a placeholder for the current version, pulled from the config, to make updating easier
- Moves the build tool info to its own page
  - Split into two sections, one for releases and the other for snapshots
- Moves the lil project description to the top of the index
- Fixes an old `TextComponent.text` reference 