### PR TITLE
Add Javadoc info to prolog

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -35,8 +35,9 @@ if release.endswith('-SNAPSHOT'):
 rst_prolog = """
 .. danger::
 
-    The Adventure docs are currently a **work in progress**. Some areas may have limited coverage or may not be entirely up to date.
-    Feel free to join our discord at `<https://discord.gg/MMfhJ8F>`_ if you have any questions.
+    The Adventure docs are currently a **work in progress** and supplement the `Javadocs <https://jd.adventure.kyori.net>`_.
+    Some areas may have limited coverage or may not be entirely up to date.
+    Feel free to join our `Discord <https://discord.gg/MMfhJ8F>`_ if you have any questions.
 
 .. |version| replace:: {version}
 


### PR DESCRIPTION
This PR adds a note about the Javadocs to the docs in the prolog, with a link to the new snazzy Javadocs page.