### PR TITLE
Added missing .build method to TagResolver

### DIFF
--- a/source/minimessage/api.rst
+++ b/source/minimessage/api.rst
@@ -133,7 +133,8 @@ To make customizing MiniMessage easier, we provide a Builder. The specific metho
           .resolver(StandardTags.color())
           .resolver(StandardTags.decorations())
           .resolver(this.additionalPlaceholders)
-         )
+          .build()
+        )
         .build();
 
 .. tip::


### PR DESCRIPTION
A ``.build()`` method was missing in the API tab