### PR TITLE
Add adventure-binary-serializer as community library

### DIFF
--- a/source/community-libraries.rst
+++ b/source/community-libraries.rst
@@ -21,14 +21,15 @@ They typically have no dependencies on a specific platform, just Adventure and p
 
 .. Elements in this table should be alphabetized
 
-===================== =================================================== ====================================================================================
-Name                  Description                                          Link
-===================== =================================================== ====================================================================================
-EnhancedLegacyText    Alternative input format that is legacy compatible  `Vankka/EnhancedLegacyText <https://github.com/Vankka/EnhancedLegacyText>`_
-                      with new features 
-MCDiscordReserializer Serializers for going between Minecraft & Discord   `Vankka/MCDiscordReserializer <https://github.com/Vankka/MCDiscordReserializer>`_
-Minedown              A markdown-style format for representing components `Phoenix616/MineDown <https://github.com/Phoenix616/MineDown/tree/kyori-adventure>`_
-===================== =================================================== ====================================================================================
+=========================== =================================================== ====================================================================================================
+Name                        Description                                          Link
+=========================== =================================================== ====================================================================================================
+adventure-binary-serializer Serializer for converting to packed bytes           `Moulberry/adventure-binary-serializer` <https://github.com/Moulberry/adventure-binary-serializer/>
+EnhancedLegacyText          Alternative input format that is legacy compatible  `Vankka/EnhancedLegacyText <https://github.com/Vankka/EnhancedLegacyText>`_
+                            with new features 
+MCDiscordReserializer       Serializers for going between Minecraft & Discord   `Vankka/MCDiscordReserializer <https://github.com/Vankka/MCDiscordReserializer>`_
+Minedown                    A markdown-style format for representing components `Phoenix616/MineDown <https://github.com/Phoenix616/MineDown/tree/kyori-adventure>`_
+=========================== =================================================== ====================================================================================================
 
 Libraries that use Adventure
 ----------------------------

--- a/source/community-libraries.rst
+++ b/source/community-libraries.rst
@@ -24,7 +24,7 @@ They typically have no dependencies on a specific platform, just Adventure and p
 =========================== =================================================== ====================================================================================================
 Name                        Description                                          Link
 =========================== =================================================== ====================================================================================================
-adventure-binary-serializer Serializer for converting to packed bytes           `Moulberry/adventure-binary-serializer` <https://github.com/Moulberry/adventure-binary-serializer/>
+adventure-binary-serializer Serializer for converting to packed bytes           `Moulberry/adventure-binary-serializer <https://github.com/Moulberry/adventure-binary-serializer/>`_
 EnhancedLegacyText          Alternative input format that is legacy compatible  `Vankka/EnhancedLegacyText <https://github.com/Vankka/EnhancedLegacyText>`_
                             with new features 
 MCDiscordReserializer       Serializers for going between Minecraft & Discord   `Vankka/MCDiscordReserializer <https://github.com/Vankka/MCDiscordReserializer>`_


### PR DESCRIPTION
Adds adventure-binary-serializer as community library, a library that serializes components to packed bytes