### PR TITLE
Dependency directive

### DIFF
--- a/source/_ext/adventure_docs_extensions/__init__.py
+++ b/source/_ext/adventure_docs_extensions/__init__.py
@@ -33,9 +33,7 @@ def setup(app: Sphinx):
     app.add_role("mojira", mojira_role)
     app.connect('html-collect-pages', _fix_cloudflare_name_mangling)
     app.add_directive("kyori-dep", KyoriDepDirective)
-    app.add_config_value("api_version", "0.0.0", "html")
-    app.add_config_value("platform_version", "0.0.0", "html")
-    app.add_config_value("platform_fabric_version", "0.0.0", "html")
+    app.add_config_value("dependency_versions", {'api': "0.0.0", 'platform': "0.0.0", 'platform_fabric': "0.0.0"}, "html", types=[dict])
 
 
 _issue_regex = re.compile(r'[A-Z]+-[1-9][0-9]*')
@@ -110,18 +108,9 @@ class KyoriDepDirective(Directive):
 
     def run(self):
         artifact = self.arguments[0]
-        version = convert_version(self.arguments[1], self.state.document.settings.env.config)
+        version = self.state.document.settings.env.config.dependency_versions[self.arguments[1]]
         dummy_parent = nodes.paragraph()
         string_list = StringList(initlist=dependencyText.format(artifact=artifact, version=version).split("\n"), source="simon")
         self.state.nested_parse(string_list, 0, dummy_parent)
 
         return dummy_parent.children
-
-
-def convert_version(version_id, config):
-    if version_id == "api":
-        return config.api_version
-    if version_id == "platform":
-        return config.platform_version
-    if version_id == "platform_fabric":
-        return config.platform_fabric_version

--- a/source/_ext/adventure_docs_extensions/__init__.py
+++ b/source/_ext/adventure_docs_extensions/__init__.py
@@ -83,8 +83,6 @@ def _fix_cloudflare_name_mangling(app: Sphinx):
 
 
 dependencyText = """
-Declaring the dependency:
-
 .. |artifact| replace:: {artifact}
 
 .. |version| replace:: {version}

--- a/source/_ext/adventure_docs_extensions/__init__.py
+++ b/source/_ext/adventure_docs_extensions/__init__.py
@@ -28,13 +28,15 @@ from docutils.statemachine import StringList
 from sphinx.application import Sphinx
 from docutils.parsers.rst import nodes
 from docutils.parsers.rst import Directive
-from source.conf import _api_version, _platform_version, _platform_fabric_version
-
 
 def setup(app: Sphinx):
     app.add_role("mojira", mojira_role)
     app.connect('html-collect-pages', _fix_cloudflare_name_mangling)
     app.add_directive("kyori-dep", KyoriDepDirective)
+    app.add_config_value("api_version", "0.0.0", "html")
+    app.add_config_value("platform_version", "0.0.0", "html")
+    app.add_config_value("platform_fabric_version", "0.0.0", "html")
+
 
 _issue_regex = re.compile(r'[A-Z]+-[1-9][0-9]*')
 _mojira_url = "https://bugs.mojang.com/browse/"
@@ -108,7 +110,7 @@ class KyoriDepDirective(Directive):
 
     def run(self):
         artifact = self.arguments[0]
-        version = convert_version(self.arguments[1])
+        version = convert_version(self.arguments[1], self.state.document.settings.env.config)
         dummy_parent = nodes.paragraph()
         string_list = StringList(initlist=dependencyText.format(artifact=artifact, version=version).split("\n"), source="simon")
         self.state.nested_parse(string_list, 0, dummy_parent)
@@ -116,10 +118,10 @@ class KyoriDepDirective(Directive):
         return dummy_parent.children
 
 
-def convert_version(version_id):
+def convert_version(version_id, config):
     if version_id == "api":
-        return _api_version
+        return config.api_version
     if version_id == "platform":
-        return _platform_version
+        return config.platform_version
     if version_id == "platform_fabric":
-        return _platform_fabric_version
+        return config.platform_fabric_version

--- a/source/conf.py
+++ b/source/conf.py
@@ -25,11 +25,17 @@ project = 'Adventure'
 copyright = '2020-2022 KyoriPowered'
 author = 'KyoriPowered'
 
-# The short X.Y version
-version = '4.11.0'
+# The short X.Y versions
 
-# The full version, including alpha/beta/rc tags
-release = version
+# The latest version of the Adventure api
+_api_version = '4.11.0'
+
+# The latest versions of adventure-platform builds
+_platform_version = '4.1.1'
+_platform_fabric_version = '5.3.1'
+
+# The full api version, including alpha/beta/rc tags
+release = _api_version
 
 if release.endswith('-SNAPSHOT'):
     tags.add('draft')
@@ -40,8 +46,6 @@ rst_prolog = f"""
     The Adventure docs are currently a **work in progress** and supplement the `Javadocs <https://jd.adventure.kyori.net>`_.
     Some areas may have limited coverage or may not be entirely up to date.
     Feel free to join our `Discord <https://discord.gg/MMfhJ8F>`_ if you have any questions.
-
-.. |version| replace:: {version}
 
 .. role:: mm(code)
     :language: minimessage
@@ -129,7 +133,7 @@ html_theme_options = {
     'sidebar_hide_name': True
 }
 
-html_title = f'Adventure Documentation (v{version})'
+html_title = f'Adventure Documentation (v{_api_version})'
 html_show_sourcelink = False
 html_copy_source = False
 html_favicon = '_static/favicon.ico'

--- a/source/conf.py
+++ b/source/conf.py
@@ -34,6 +34,8 @@ api_version = '4.11.0'
 platform_version = '4.1.1'
 platform_fabric_version = '5.3.1'
 
+dependency_versions = {'api': api_version, 'platform': platform_version, 'platform_fabric': platform_fabric_version}
+
 # The full api version, including alpha/beta/rc tags
 release = api_version
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -28,14 +28,14 @@ author = 'KyoriPowered'
 # The short X.Y versions
 
 # The latest version of the Adventure api
-_api_version = '4.11.0'
+api_version = '4.11.0'
 
 # The latest versions of adventure-platform builds
-_platform_version = '4.1.1'
-_platform_fabric_version = '5.3.1'
+platform_version = '4.1.1'
+platform_fabric_version = '5.3.1'
 
 # The full api version, including alpha/beta/rc tags
-release = _api_version
+release = api_version
 
 if release.endswith('-SNAPSHOT'):
     tags.add('draft')
@@ -47,7 +47,7 @@ rst_prolog = f"""
     Some areas may have limited coverage or may not be entirely up to date.
     Feel free to join our `Discord <https://discord.gg/MMfhJ8F>`_ if you have any questions.
 
-.. |fabric_version| replace:: {_platform_fabric_version}
+.. |fabric_version| replace:: {platform_fabric_version}
 
 .. role:: mm(code)
     :language: minimessage
@@ -135,7 +135,7 @@ html_theme_options = {
     'sidebar_hide_name': True
 }
 
-html_title = f'Adventure Documentation (v{_api_version})'
+html_title = f'Adventure Documentation (v{api_version})'
 html_show_sourcelink = False
 html_copy_source = False
 html_favicon = '_static/favicon.ico'

--- a/source/conf.py
+++ b/source/conf.py
@@ -47,6 +47,8 @@ rst_prolog = f"""
     Some areas may have limited coverage or may not be entirely up to date.
     Feel free to join our `Discord <https://discord.gg/MMfhJ8F>`_ if you have any questions.
 
+.. |fabric_version| replace:: {_platform_fabric_version}
+
 .. role:: mm(code)
     :language: minimessage
     :class: highlight

--- a/source/contributing.rst
+++ b/source/contributing.rst
@@ -95,8 +95,16 @@ While we try to rely on external projects as much as possible, there are some sm
 
     For example, ``:mojira:`MC-4``` will produce :mojira:`MC-4`
 
+.. rst:directive:: kyori-dep
 
-MiniMessage syntax
+    The ``kyori-dep`` directive inserts a dependency block for a kyori module. The directive takes two parameters,
+    artifact and version type(api, platform or platform_fabric).
+
+    For example, ``..kyori-dep:: adventure-api api`` will produce:
+
+        .. kyori-dep:: adventure-api api
+
+MniMessage syntax
 ~~~~~~~~~~~~~~~~~~
 
 This documentation has MiniMessage syntax highlighting enabled. In code blocks, this can be used with the ``mm`` or ``minimessage`` languages:

--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -13,6 +13,8 @@ To view the list of platforms that include Adventure, see :doc:`/platform/native
 To use Adventure with other platforms, you may wish to look at the platform-specific adapters.
 A list of platforms with supported adapters can be found at :doc:`/platform/index`.
 
+.. _snapshot-reference:
+
 Using Snapshot Builds
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/source/getting-started.rst
+++ b/source/getting-started.rst
@@ -4,48 +4,7 @@ Getting Started
 
 To use Adventure in your project, you will need to add the following dependency and repository (if using Gradle):
 
-.. tab-set::
-
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code-block:: xml
-        :substitutions:
-
-         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-api</artifactId>
-            <version>|version|</version>
-         </dependency>
-
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code-block:: groovy
-        :substitutions:
-
-         repositories {
-           mavenCentral()
-         }
-
-         dependencies {
-            implementation "net.kyori:adventure-api:|version|"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code-block:: kotlin
-        :substitutions:
-
-         repositories {
-           mavenCentral()
-         }
-
-         dependencies {
-            implementation("net.kyori:adventure-api:|version|")
-         }
+.. kyori-dep:: adventure-api api
 
 Some platforms already use Adventure natively.
 In this case, you will not need to add Adventure as a dependency.

--- a/source/minimessage/api.rst
+++ b/source/minimessage/api.rst
@@ -55,40 +55,7 @@ Adding the repository
 
 Declaring the dependency:
 
-.. tab-set::
-
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code-block:: xml
-        :substitutions:
-
-         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-minimessage</artifactId>
-            <version>|version|</version>
-         </dependency>
-
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code-block:: groovy
-        :substitutions:
-
-         dependencies {
-            implementation "net.kyori:adventure-text-minimessage:|version|"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code-block:: kotlin
-        :substitutions:
-
-         dependencies {
-            implementation("net.kyori:adventure-text-minimessage:|version|")
-         }
+.. kyori-dep:: adventure-text-minimessage api
 
 
 Getting Started

--- a/source/platform/bukkit.rst
+++ b/source/platform/bukkit.rst
@@ -5,54 +5,6 @@ Bukkit
 The Adventure platform implementation for Bukkit targets Paper, Spigot, and Bukkit for
 Minecraft 1.7.10 through 1.18.2.
 
-Add the artifact to your build file:
-
-First, add the repository:
-
-.. tab-set::
-   
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code:: xml
-
-         <repositories>
-             <!-- ... -->
-             <repository> <!-- for development builds -->
-               <id>sonatype-oss-snapshots1</id>
-               <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-             </repository>
-             <!-- ... -->
-         </repositories>
-   
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code:: groovy
-
-         repositories {
-            // for development builds
-            maven {
-                name = "sonatype-oss-snapshots1"
-                url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            }
-            // for releases
-            mavenCentral()
-         }
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code:: kotlin
-
-         repositories {
-            // for development builds
-            maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-                name = "sonatype-oss-snapshots1"
-            }
-            // for releases
-            mavenCentral()
-         }
 
 .. kyori-dep:: adventure-platform-bukkit platform
 

--- a/source/platform/bukkit.rst
+++ b/source/platform/bukkit.rst
@@ -54,39 +54,7 @@ First, add the repository:
             mavenCentral()
          }
 
-Declaring the dependency:
-
-.. tab-set::
-   
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code:: xml
-
-         <dependency>
-         <groupId>net.kyori</groupId>
-         <artifactId>adventure-platform-bukkit</artifactId>
-         <version>4.1.0</version>
-         </dependency>
-   
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code:: groovy
-
-         dependencies {
-            implementation "net.kyori:adventure-platform-bukkit:4.1.0"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code:: kotlin
-
-         dependencies {
-            implementation("net.kyori:adventure-platform-bukkit:4.1.0")
-         }
+.. kyori-dep:: adventure-platform-bukkit platform
 
 Usage
 -----

--- a/source/platform/bungeecord.rst
+++ b/source/platform/bungeecord.rst
@@ -5,55 +5,6 @@ BungeeCord
 Adventure targets the latest version of BungeeCord and BungeeCord-compatible
 forks, such as Waterfall.
 
-Add the artifact to your build file:
-
-First, add the repository:
-
-.. tab-set::
-   
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code:: xml
-
-         <repositories>
-             <!-- ... -->
-             <repository> <!-- for development builds -->
-               <id>sonatype-oss-snapshots1</id>
-               <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-             </repository>
-             <!-- ... -->
-         </repositories>
-   
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code:: groovy
-
-         repositories {
-            // for development builds
-            maven {
-                name = "sonatype-oss-snapshots1"
-                url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            }
-            // for releases
-            mavenCentral()
-         }
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code:: kotlin
-
-         repositories {
-            // for development builds
-            maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-                name = "sonatype-oss-snapshots1"
-            }
-            // for releases
-            mavenCentral()
-         }
-
 .. kyori-dep:: adventure-platform-bungeecord platform
 
 Usage

--- a/source/platform/bungeecord.rst
+++ b/source/platform/bungeecord.rst
@@ -54,39 +54,7 @@ First, add the repository:
             mavenCentral()
          }
 
-Declaring the dependency:
-
-.. tab-set::
-   
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code:: xml
-
-         <dependency>
-         <groupId>net.kyori</groupId>
-         <artifactId>adventure-platform-bungeecord</artifactId>
-         <version>4.1.0</version>
-         </dependency>
-   
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code:: groovy
-
-         dependencies {
-            implementation "net.kyori:adventure-platform-bungeecord:4.1.0"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code:: kotlin
-
-         dependencies {
-            implementation("net.kyori:adventure-platform-bungeecord:4.1.0")
-         }
+.. kyori-dep:: adventure-platform-bungeecord platform
 
 Usage
 -----

--- a/source/platform/fabric.rst
+++ b/source/platform/fabric.rst
@@ -56,20 +56,22 @@ First, add the repository:
    .. tab-item:: Gradle (Groovy)
       :sync: gradle-groovy
 
-      .. code:: groovy
+      .. code-block:: groovy
+        :substitutions:
 
          dependencies {
-            modImplementation include("net.kyori:adventure-platform-fabric:5.3.1") // for Minecraft 1.18.2
+            modImplementation include("net.kyori:adventure-platform-fabric:|fabric_version|") // for Minecraft 1.18.2
          }
 
 
    .. tab-item:: Gradle (Kotlin)
       :sync: gradle-kotlin
 
-      .. code:: kotlin
+      .. code-block:: kotlin
+        :substitutions:
 
          dependencies {
-            modImplementation(include("net.kyori:adventure-platform-fabric:5.3.1")!!) // for Minecraft 1.18.2
+            modImplementation(include("net.kyori:adventure-platform-fabric:|fabric_version|")!!) // for Minecraft 1.18.2
          }
 
 The Fabric platform requires *fabric-api-base* in order to provide the locale change event, and can optionally use Colonel_ to allow the ``Component`` and ``Key`` argument types to be used on clients without the mod installed. There are no other dependencies.

--- a/source/platform/spongeapi.rst
+++ b/source/platform/spongeapi.rst
@@ -4,55 +4,6 @@ SpongeAPI
 
 Adventure provides a platform for SpongeAPI 7 for *Minecraft: Java Edition* 1.12. For SpongeAPI 8 and up (targeting *Minecraft: Java Edition* 1.16.4), Adventure is the native text library, so no platform is needed.
 
-To get started using this platform, add the artifact to your build file:
-
-First, add the repository:
-
-.. tab-set::
-   
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code:: xml
-
-         <repositories>
-             <!-- ... -->
-             <repository> <!-- for development builds -->
-               <id>sonatype-oss-snapshots1</id>
-               <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-             </repository>
-             <!-- ... -->
-         </repositories>
-   
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code:: groovy
-
-         repositories {
-            // for development builds
-            maven {
-                name = "sonatype-oss-snapshots1"
-                url = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
-            }
-            // for releases
-            mavenCentral()
-         }
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code:: kotlin
-
-         repositories {
-            // for development builds
-            maven(url = "https://s01.oss.sonatype.org/content/repositories/snapshots/") {
-                name = "sonatype-oss-snapshots1"
-            }
-            // for releases
-            mavenCentral()
-         }
-
 .. kyori-dep:: adventure-platform-spongeapi platform
 
 Usage

--- a/source/platform/spongeapi.rst
+++ b/source/platform/spongeapi.rst
@@ -53,40 +53,7 @@ First, add the repository:
             mavenCentral()
          }
 
-Declaring the dependency:
-
-.. tab-set::
-   
-   .. tab-item:: Maven
-      :sync: maven
-
-      .. code:: xml
-
-         <dependency>
-         <groupId>net.kyori</groupId>
-         <artifactId>adventure-platform-spongeapi</artifactId>
-         <version>4.1.0</version>
-         </dependency>
-   
-   .. tab-item:: Gradle (Groovy)
-      :sync: gradle-groovy
-
-      .. code:: groovy
-
-         dependencies {
-            implementation "net.kyori:adventure-platform-spongeapi:4.1.0"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-      :sync: gradle-kotlin
-
-      .. code:: kotlin
-
-         dependencies {
-            implementation("net.kyori:adventure-platform-spongeapi:4.1.0")
-         }
-
+.. kyori-dep:: adventure-platform-spongeapi platform
 
 Usage
 ~~~~~

--- a/source/serializer/gson.rst
+++ b/source/serializer/gson.rst
@@ -11,40 +11,7 @@ An average user of this text serializer will typically want to only deserialize 
 component from an external source - serialization is done automatically by the
 :doc:`/platform/index` when the component is sent to the user.
 
-**Importing this serializer into your project**
-
-.. tab-set::
-
-   .. tab-item:: Maven
-
-      .. code-block:: xml
-        :substitutions:
-
-         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>|version|</version>
-         </dependency>
-
-   .. tab-item:: Gradle (Groovy)
-
-      .. code-block:: groovy
-        :substitutions:
-
-         dependencies {
-            implementation "net.kyori:adventure-text-serializer-gson:|version|"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-
-      .. code-block:: kotlin
-        :substitutions:
-
-         dependencies {
-            implementation("net.kyori:adventure-text-serializer-gson:|version|")
-         }
-
+.. kyori-dep:: adventure-text-serializer-gson api
 
 Usage
 -----

--- a/source/serializer/legacy.rst
+++ b/source/serializer/legacy.rst
@@ -13,39 +13,7 @@ into clickable components if explicitly requested (note, however, that click eve
 containing a URL will *not* be serialized). If advanced features are desired, consider
 using :doc:`/minimessage/index`.
 
-**Importing this serializer into your project**
-
-.. tab-set::
-
-   .. tab-item:: Maven
-
-      .. code-block:: xml
-        :substitutions:
-
-         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-serializer-legacy</artifactId>
-            <version>|version|</version>
-         </dependency>
-
-   .. tab-item:: Gradle (Groovy)
-
-      .. code-block:: groovy
-        :substitutions:
-
-         dependencies {
-            implementation "net.kyori:adventure-text-serializer-legacy:|version|"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-
-      .. code-block:: kotlin
-        :substitutions:
-
-         dependencies {
-            implementation("net.kyori:adventure-text-serializer-legacy:|version|")
-         }
+.. kyori-dep:: adventure-text-serializer-legacy api
 
 
 Usage

--- a/source/serializer/plain.rst
+++ b/source/serializer/plain.rst
@@ -12,39 +12,7 @@ The plain text serializer, by its nature, does not support any advanced features
 color, hover and click events, URL linking, or insertions. If advanced features are desired,
 consider using :doc:`/minimessage/index`.
 
-**Importing this serializer into your project**
-
-.. tab-set::
-
-   .. tab-item:: Maven
-
-      .. code-block:: xml
-        :substitutions:
-
-         <dependency>
-            <groupId>net.kyori</groupId>
-            <artifactId>adventure-text-serializer-plain</artifactId>
-            <version>|version|</version>
-         </dependency>
-
-   .. tab-item:: Gradle (Groovy)
-
-      .. code-block:: groovy
-        :substitutions:
-
-         dependencies {
-            implementation "net.kyori:adventure-text-serializer-plain:|version|"
-         }
-
-
-   .. tab-item:: Gradle (Kotlin)
-
-      .. code-block:: kotlin
-        :substitutions:
-
-         dependencies {
-            implementation("net.kyori:adventure-text-serializer-plain:|version|")
-         }
+.. kyori-dep:: adventure-text-serializer-plain api
 
 Usage
 -----

--- a/source/shared/dependency.rst
+++ b/source/shared/dependency.rst
@@ -1,0 +1,31 @@
+.. tab-set::
+
+   .. tab-item:: Maven
+
+      .. code-block:: xml
+        :substitutions:
+
+         <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>|artifact|</artifactId>
+            <version>|version|</version>
+         </dependency>
+
+   .. tab-item:: Gradle (Groovy)
+
+      .. code-block:: groovy
+        :substitutions:
+
+         dependencies {
+            implementation "net.kyori:|artifact|:|version|"
+         }
+
+
+   .. tab-item:: Gradle (Kotlin)
+
+      .. code-block:: kotlin
+        :substitutions:
+
+         dependencies {
+            implementation("net.kyori:|artifact|:|version|")
+         }

--- a/source/shared/dependency.rst
+++ b/source/shared/dependency.rst
@@ -1,3 +1,5 @@
+Declaring the dependency:
+
 .. tab-set::
 
    .. tab-item:: Maven
@@ -16,6 +18,10 @@
       .. code-block:: groovy
         :substitutions:
 
+         repositories {
+            mavenCentral()
+         }
+
          dependencies {
             implementation "net.kyori:|artifact|:|version|"
          }
@@ -26,6 +32,12 @@
       .. code-block:: kotlin
         :substitutions:
 
+         repositories {
+            mavenCentral()
+         }
+
          dependencies {
             implementation("net.kyori:|artifact|:|version|")
          }
+
+Need development/snapshot builds? :ref:`snapshot-reference`


### PR DESCRIPTION
Adds a simple directive that generates a dependency info block as drafted in `shared/dependency.rst`(new file).
The `version` and `artifact` variables are given in the directive as such:

`.. kyori-dep:: adventure-api api`

Where the first argument is the artifact and the second is the version type(api, platform or platform_fabric)

Rendered example:
<img width="782" alt="Skjermbilde 2022-06-24 kl  00 46 54" src="https://user-images.githubusercontent.com/19822231/175427444-f38c7df1-2ec3-49aa-b7a4-ee7090612b0b.png">

`Using Snapshot Builds` links to the second header in the getting started page:
<img width="773" alt="Skjermbilde 2022-06-24 kl  00 48 50" src="https://user-images.githubusercontent.com/19822231/175427609-2e683b76-d53d-4e77-990f-6595f4b3545d.png">

I guess this would close #92 and #48 ?