### PR TITLE
Add a FAQ section based on information that is currently locked on our Discord

### DIFF
--- a/source/faq.md
+++ b/source/faq.md
@@ -5,7 +5,7 @@ We find that there are some issues users come across relatively frequently while
 
 ## Why is my lore in italics?
 
-Components will inherit style from their parent. For example, in the following code snippet, each word will be red, despite red not being explicitly set on the appended component: text("hi", RED).append(text("also red!")).
+Components will inherit style from their parent. For example, in the following code snippet, each word will be red, despite red not being explicitly set on the appended component: {java}`text("hi", RED).append(text("also red!"))`.
 
 In vanilla Minecraft, some places were components are rendered have parent styles. For example, lore text has a parent style that makes all text italic. This means that you will need to set italic to false if you do not want any component you are storing in lore to be italic. The {java}`Component.decorationIfAbsent()` method can apply this to existing components without overriding any formatting specifically set by users.
 

--- a/source/faq.md
+++ b/source/faq.md
@@ -1,0 +1,71 @@
+FAQ
+===
+
+We find that there are some issues users come across relatively frequently while applying the Adventure library in certain contexts. These may not be directly related to Adventure itself, but these answers are published here those that ask them:
+
+## Why is my lore in italics?
+
+Components will inherit style from their parent. For example, in the following code snippet, each word will be red, despite red not being explicitly set on the appended component: text("hi", RED).append(text("also red!")).
+
+In vanilla Minecraft, some places were components are rendered have parent styles. For example, lore text has a parent style that makes all text italic. This means that you will need to set italic to false if you do not want any component you are storing in lore to be italic. The {java}`Component.decorationIfAbsent()` method can apply this to existing components without overriding any formatting specifically set by users.
+
+## Messages not sending? Hex colours not working? Events not appearing? Fonts messed up?
+
+- Test on a vanilla client. Modded clients such as Lunar, Badlion and others commonly break many elements of the modern JSON chat format and mess with incoming chat packets in ways that cause a myriad of issues.
+- Try without other plugins/mods. If another plugin/mod is modifying outgoing packets or formatting chat messages, this could cause a loss of formatting in the messages you send. Try without any other plugins to see if any are causing issues.
+- For RGB colors, test on a client of at least version *1.16*. Mojang added RGB support in this version. The JSON message format has evolved over time and has had many new additions since its introduction many, many years ago. For a full version history, see [the Minecraft wiki](https://breezewiki.com/minecraft/wiki/Raw_JSON_text_format).
+
+## How can I support both MiniMessage and legacy (§-code) formatting?
+
+If you have legacy in config files, or other places, it is suggested that you migrate them once using the legacy deserialiser to turn them into a component and then MiniMessage to serialise them into proper MiniMessage format.
+
+There are no working, recommended or supported ways of using both MiniMessage and legacy colour codes and there never will be. Even simple find-and-replace style techniques do not work and will fail to take into account the quirks of style resetting in legacy formatting.
+
+## How can I use Bukkit's PlaceholderAPI in MiniMessage messages?
+
+PlaceholderAPI placeholders are not supported in MiniMessage. However, you can easily create a custom tag resolver that can allow users to use PlaceholderAPI placeholders in MiniMessage strings, like in the following example:
+
+````{dropdown} Example
+
+Example method to create a MiniMessage placeholder that parses PlaceholderAPI placeholders for a player.
+
+The tag added is of the format {mm}`<papi:[papi_placeholder]>`. For example, {mm}`<papi:luckperms_prefix>`.
+
+Credit to mbaxter.
+
+```java
+/**
+* Creates a tag resolver capable of resolving PlaceholderAPI tags for a given player.
+*
+* @param player the player
+* @return the tag resolver
+*/
+public @NotNull TagResolver papiTag(final @NotNull Player player) {
+    return TagResolver.resolver("papi", (argumentQueue, context) -> {
+        // Get the string placeholder that they want to use.
+        final String papiPlaceholder = argumentQueue.popOr("papi tag requires an argument").value();
+
+        // Then get PAPI to parse the placeholder for the given player.
+        final String parsedPlaceholder = PlaceholderAPI.setPlaceholders(player, '%' + papiPlaceholder + '%');
+
+        // We need to turn this ugly legacy string into a nice component.
+        final Component componentPlaceholder = LegacyComponentSerializer.legacySection().deserialize(parsedPlaceholder);
+
+        // Finally, return the tag instance to insert the placeholder!
+        return Tag.selfClosingInserting(componentPlaceholder);
+    });
+}
+```
+
+````
+
+## Why am I getting a `NoSuchFieldError`, `NoSuchMethodError`, `ClassNotFoundException` or similar when updating/using `adventure-platform-*`, `adventure-text-minimessage`, `adventure-api` or other related libraries/tools?
+
+In the case of `adventure-platform-fabric`, you need to make sure you are properly include()-ing the mod. For legacy platform implementations, you need to make sure you are properly shading and relocating your specific dependencies. Specific issues may include:
+
+- Not shading the correct version of adventure-api. You can check your dependency tree to see what or why your build tool is not including the correct version of the API that matches the one used by the platform version you are using.
+- Not relocating your dependencies. If you are running on a platform that includes an older version of the API, or another mod/plugin is also not properly relocating their dependencies, you will use their out-of-date version of the API, causing errors.
+- Building/running against a native implementation of adventure-api.  If you are running on a platform that includes an older version of the API, this could cause issues if the library depends on newer features that are not available in the outdated version of the API, your library will not be able to find these methods, causing errors.
+- Relocating adventure-api and trying to use native/library methods. If you relocate the API, you will not be able to use any methods that use the API in native implementations or libraries as method signatures will differ. Either shade and relocate this software, or do not use native methods. Alternatively, if you are shading and relocating a library but want to use the the API, make sure you are only relocating the packages that you are shading.
+
+Please consult the documentation for your build tool for more information on how to shade, relocate and manage your dependencies. We do not provide one-on-one support for these sorts of issues, as there are far too many project-specific variables that make isolating issues difficult.

--- a/source/faq.md
+++ b/source/faq.md
@@ -17,7 +17,7 @@ In vanilla Minecraft, some places where components are rendered have parent styl
 
 ## How can I support both MiniMessage and legacy (§-code) formatting?
 
-If you have legacy in config files, or other places, it is suggested that you migrate them once using the legacy deserializer to turn them into a component and then MiniMessage to serialize them into proper MiniMessage format.
+If you have legacy in configuration files, or other places, it is suggested that you migrate them once using the legacy deserializer to turn them into a component and then MiniMessage to serialize them into proper MiniMessage format.
 
 There are no working, recommended, or supported ways of using both MiniMessage and legacy color codes and there never will be. Even simple find-and-replace style techniques do not work and will fail to take into account the quirks of style resetting in legacy formatting.
 
@@ -31,7 +31,7 @@ Example method to create a MiniMessage placeholder that parses PlaceholderAPI pl
 
 The tag added is of the format {mm}`<papi:[papi_placeholder]>`. For example, {mm}`<papi:luckperms_prefix>`.
 
-Credit to mbaxter.
+Credit to {spelling:ignore}`mbaxter`.
 
 ```java
 /**
@@ -61,7 +61,7 @@ public @NotNull TagResolver papiTag(final @NotNull Player player) {
 
 ## Why am I getting a `NoSuchFieldError`, `NoSuchMethodError`, `ClassNotFoundException` or similar when updating/using `adventure-platform-*`, `adventure-text-minimessage`, `adventure-api` or other related libraries/tools?
 
-In the case of `adventure-platform-fabric`, you need to make sure you are properly include()-ing the mod. For legacy platform implementations, you need to make sure you are properly shading and relocating your specific dependencies. Specific issues may include:
+In the case of `adventure-platform-fabric`, you need to make sure you are properly `include()`-{spelling:ignore}`ing` the mod. For legacy platform implementations, you need to make sure you are properly shading and relocating your specific dependencies. Specific issues may include:
 
 - Not shading the correct version of `adventure-api`. You can check your dependency tree to see what or why your build tool is not including the correct version of the API that matches the one used by the platform version you are using.
 - Not relocating your dependencies. If you are running on a platform that includes an older version of the API, or another mod/plugin is also not properly relocating their dependencies, you will use their out-of-date version of the API, causing errors.

--- a/source/faq.md
+++ b/source/faq.md
@@ -7,7 +7,7 @@ We find that there are some issues users come across relatively frequently while
 
 Components will inherit style from their parent. For example, in the following code snippet, each word will be red, despite red not being explicitly set on the appended component: {java}`text("hi", RED).append(text("also red!"))`.
 
-In vanilla Minecraft, some places were components are rendered have parent styles. For example, lore text has a parent style that makes all text italic. This means that you will need to set italic to false if you do not want any component you are storing in lore to be italic. The {java}`Component.decorationIfAbsent()` method can apply this to existing components without overriding any formatting specifically set by users.
+In vanilla Minecraft, some places where components are rendered have parent styles. For example, lore text has a parent style that makes all text italic. This means that you will need to set italic to false if you do not want any component you are storing in lore to be italic. The {java}`Component.decorationIfAbsent()` method can apply this to existing components without overriding any formatting specifically set by users.
 
 ## Messages not sending? Hex colours not working? Events not appearing? Fonts messed up?
 

--- a/source/faq.md
+++ b/source/faq.md
@@ -9,7 +9,7 @@ Components will inherit style from their parent. For example, in the following c
 
 In vanilla Minecraft, some places where components are rendered have parent styles. For example, lore text has a parent style that makes all text italic. This means that you will need to set italic to false if you do not want any component you are storing in lore to be italic. The {java}`Component.decorationIfAbsent()` method can apply this to existing components without overriding any formatting specifically set by users.
 
-## Messages not sending? Hex colours not working? Events not appearing? Fonts messed up?
+## Messages not sending? Hex colors not working? Events not appearing? Fonts messed up?
 
 - Test on a vanilla client. Modded clients such as Lunar, Badlion and others commonly break many elements of the modern JSON chat format and mess with incoming chat packets in ways that cause a myriad of issues.
 - Try without other plugins/mods. If another plugin/mod is modifying outgoing packets or formatting chat messages, this could cause a loss of formatting in the messages you send. Try without any other plugins to see if any are causing issues.
@@ -17,9 +17,9 @@ In vanilla Minecraft, some places where components are rendered have parent styl
 
 ## How can I support both MiniMessage and legacy (§-code) formatting?
 
-If you have legacy in config files, or other places, it is suggested that you migrate them once using the legacy deserialiser to turn them into a component and then MiniMessage to serialise them into proper MiniMessage format.
+If you have legacy in config files, or other places, it is suggested that you migrate them once using the legacy deserializer to turn them into a component and then MiniMessage to serialize them into proper MiniMessage format.
 
-There are no working, recommended, or supported ways of using both MiniMessage and legacy colour codes and there never will be. Even simple find-and-replace style techniques do not work and will fail to take into account the quirks of style resetting in legacy formatting.
+There are no working, recommended, or supported ways of using both MiniMessage and legacy color codes and there never will be. Even simple find-and-replace style techniques do not work and will fail to take into account the quirks of style resetting in legacy formatting.
 
 ## How can I use Bukkit's PlaceholderAPI in MiniMessage messages?
 
@@ -63,9 +63,9 @@ public @NotNull TagResolver papiTag(final @NotNull Player player) {
 
 In the case of `adventure-platform-fabric`, you need to make sure you are properly include()-ing the mod. For legacy platform implementations, you need to make sure you are properly shading and relocating your specific dependencies. Specific issues may include:
 
-- Not shading the correct version of adventure-api. You can check your dependency tree to see what or why your build tool is not including the correct version of the API that matches the one used by the platform version you are using.
+- Not shading the correct version of `adventure-api`. You can check your dependency tree to see what or why your build tool is not including the correct version of the API that matches the one used by the platform version you are using.
 - Not relocating your dependencies. If you are running on a platform that includes an older version of the API, or another mod/plugin is also not properly relocating their dependencies, you will use their out-of-date version of the API, causing errors.
-- Building/running against a native implementation of adventure-api.  If you are running on a platform that includes an older version of the API, this could cause issues if the library depends on newer features that are not available in the outdated version of the API, your library will not be able to find these methods, causing errors.
-- Relocating adventure-api and trying to use native/library methods. If you relocate the API, you will not be able to use any methods that use the API in native implementations or libraries as method signatures will differ. Either shade and relocate this software, or do not use native methods. Alternatively, if you are shading and relocating a library but want to use the the API, make sure you are only relocating the packages that you are shading.
+- Building/running against a native implementation of `adventure-api`.  If you are running on a platform that includes an older version of the API, this could cause issues if the library depends on newer features that are not available in the outdated version of the API, your library will not be able to find these methods, causing errors.
+- Relocating `adventure-api` and trying to use native/library methods. If you relocate the API, you will not be able to use any methods that use the API in native implementations or libraries as method signatures will differ. Either shade and relocate this software, or do not use native methods. Alternatively, if you are shading and relocating a library but want to use the API, make sure you are only relocating the packages that you are shading.
 
 Please consult the documentation for your build tool for more information on how to shade, relocate and manage your dependencies. We do not provide one-on-one support for these sorts of issues, as there are far too many project-specific variables that make isolating issues difficult.

--- a/source/faq.md
+++ b/source/faq.md
@@ -19,7 +19,7 @@ In vanilla Minecraft, some places were components are rendered have parent style
 
 If you have legacy in config files, or other places, it is suggested that you migrate them once using the legacy deserialiser to turn them into a component and then MiniMessage to serialise them into proper MiniMessage format.
 
-There are no working, recommended or supported ways of using both MiniMessage and legacy colour codes and there never will be. Even simple find-and-replace style techniques do not work and will fail to take into account the quirks of style resetting in legacy formatting.
+There are no working, recommended, or supported ways of using both MiniMessage and legacy colour codes and there never will be. Even simple find-and-replace style techniques do not work and will fail to take into account the quirks of style resetting in legacy formatting.
 
 ## How can I use Bukkit's PlaceholderAPI in MiniMessage messages?
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -23,6 +23,7 @@ There are many community-supported libraries that extend the capabilities of Adv
 
    getting-started
    community-libraries
+   faq
 
    audiences
    text

--- a/source/platform/index.rst
+++ b/source/platform/index.rst
@@ -26,6 +26,6 @@ allow you to obtain ``Audience`` instances from native user types.
 
   Next, make sure that the feature you are using exists on the client version that is receiving the action. For example, hex colour codes won't work on clients older than 1.16, so hex colours will be down-sampled.
 
-  If it's still not working, it is useful to enable debug mode by setting the system property ``net.kyori.adventure.debug`` to ``true`` and pasteing (to a pastebin such as https://paste.gg/) the output
+  If it's still not working, it is useful to enable debug mode by setting the system property ``net.kyori.adventure.debug`` to ``true`` and pasting (to a pastebin such as https://paste.gg/) the output
   in the appropriate ``#platform-`` channel on our Discord.
   This will show what facets are being selected which will help point towards why it is not working for you.

--- a/source/platform/index.rst
+++ b/source/platform/index.rst
@@ -24,8 +24,8 @@ allow you to obtain ``Audience`` instances from native user types.
 
   Firstly, please ensure you are on the latest stable version. This can be found on `Maven Central <https://search.maven.org/search?q=g:net.kyori%20AND%20a:adventure-platform*>`_.
 
-  Next, make sure that the feature you are using exists on the client version that is receiving the action. For example, hex colour codes won't work on clients older than 1.16, so hex colours will be down-sampled.
+  Next, make sure that the feature you are using exists on the client version that is receiving the action. For example, hex color codes won't work on clients older than 1.16, so hex colors will be down-sampled.
 
-  If it's still not working, it is useful to enable debug mode by setting the system property ``net.kyori.adventure.debug`` to ``true`` and pasting (to a pastebin such as https://paste.gg/) the output
+  If it's still not working, it is useful to enable debug mode by setting the system property ``net.kyori.adventure.debug`` to ``true`` and pasting (to a paste site such as https://paste.gg/) the output
   in the appropriate ``#platform-`` channel on our Discord.
   This will show what facets are being selected which will help point towards why it is not working for you.

--- a/source/platform/index.rst
+++ b/source/platform/index.rst
@@ -18,3 +18,14 @@ allow you to obtain ``Audience`` instances from native user types.
    spongeapi
    fabric
    viaversion
+
+.. note::
+  **Why is adventure-platform not sending any messages or not working correctly?**
+
+  Firstly, please ensure you are on the latest stable version. This can be found on `Maven Central <https://search.maven.org/search?q=g:net.kyori%20AND%20a:adventure-platform*>`_.
+
+  Next, make sure that the feature you are using exists on the client version that is receiving the action. For example, hex colour codes won't work on clients older than 1.16, so hex colours will be down-sampled.
+
+  If it's still not working, it is useful to enable debug mode by setting the system property ``net.kyori.adventure.debug`` to ``true`` and pasteing (to a pastebin such as https://paste.gg/) the output
+  in the appropriate ``#platform-`` channel on our Discord.
+  This will show what facets are being selected which will help point towards why it is not working for you.


### PR DESCRIPTION
Closes GH-105

@kezz i hope you don't mind that i stole your PAPI gist to include directly as an example :)

[Direct FAQ page preview link](https://kyoripowered.github.io/adventure-docs-previews/pull/110/faq.html)