### PR TITLE
chore: Cleanup "messages are messed up" FAQ entry

### DIFF
--- a/source/faq.md
+++ b/source/faq.md
@@ -11,7 +11,7 @@ In vanilla Minecraft, some places where components are rendered have parent styl
 
 ## Messages not sending? Hex colors not working? Events not appearing? Fonts messed up?
 
-- Test on a vanilla client. Modded clients such as Lunar, Badlion and others commonly break many elements of the modern JSON chat format and mess with incoming chat packets in ways that cause a myriad of issues.
+- Test on a vanilla client, without any mods or resource packs. Modded clients (such as Badlion), client mods, and even resource packs can break many elements of the modern JSON chat format and mess with incoming chat packets in ways that cause a myriad of issues.
 - Try without other plugins/mods. If another plugin/mod is modifying outgoing packets or formatting chat messages, this could cause a loss of formatting in the messages you send. Try without any other plugins to see if any are causing issues.
 - For RGB colors, test on a client of at least version *1.16*. Mojang added RGB support in this version. The JSON message format has evolved over time and has had many new additions since its introduction many, many years ago. For a full version history, see [the Minecraft wiki](https://breezewiki.com/minecraft/wiki/Raw_JSON_text_format).
 


### PR DESCRIPTION
Lunar no longer causes any issues with component renderering, so we can remove that. The most common offenders nowadays are client "optimisation" mods and weird resource packs, so we should mention those there too.