### PR TITLE
Updated description of MiniPlaceholders

### DIFF
--- a/source/community-libraries.rst
+++ b/source/community-libraries.rst
@@ -49,8 +49,8 @@ Core                The Core allows you to register (mini)messages to a central 
 Creative            A resource-pack library for Minecraft: Java Edition                   `Creative <https://github.com/unnamed/creative>`_
 Inventory Framework An inventory framework for managing GUIs                              `Inventory Framework <https://github.com/stefvanschie/IF>`_
 LiteCommands        A annotation based command framework for Velocity, Bukkit, BungeeCord `LiteCommands <https://github.com/Rollczi/LiteCommands>`_
-MiniPlaceholders    MiniMessage Component-based Placeholders for PaperMC, Krypton and     `MiniPlaceholders <https://github.com/MiniPlaceholders/MiniPlaceholders>`_
-                    Velocity platforms
+MiniPlaceholders    MiniMessage Component-based Placeholders for Paper, Fabric, Sponge,   `MiniPlaceholders <https://github.com/MiniPlaceholders/MiniPlaceholders>`_
+                    Folia and Velocity platforms
 ProtocolSidebar     An easy to use sidebar library for Paper/Spigot servers               `CatCoderr/ProtocolSidebar <https://github.com/CatCoderr/ProtocolSidebar>`_
 ScoreboardLibrary   A scoreboard library for Paper/Spigot servers                         `MegavexNetwork/scoreboard-library <https://github.com/MegavexNetwork/scoreboard-library>`_
 Triumph GUI         A library made to simplify the creation of inventory GUIs             `Triumph GUI <https://mf.mattstudios.me/triumph-gui/introduction>`_

--- a/source/community-libraries.rst
+++ b/source/community-libraries.rst
@@ -49,8 +49,7 @@ Core                The Core allows you to register (mini)messages to a central 
 Creative            A resource-pack library for Minecraft: Java Edition                   `Creative <https://github.com/unnamed/creative>`_
 Inventory Framework An inventory framework for managing GUIs                              `Inventory Framework <https://github.com/stefvanschie/IF>`_
 LiteCommands        A annotation based command framework for Velocity, Bukkit, BungeeCord `LiteCommands <https://github.com/Rollczi/LiteCommands>`_
-MiniPlaceholders    MiniMessage Component-based Placeholders for Paper, Fabric, Sponge,   `MiniPlaceholders <https://github.com/MiniPlaceholders/MiniPlaceholders>`_
-                    Folia and Velocity platforms
+MiniPlaceholders    A platform-agnostic MiniMessage Component-based Placeholders library  `MiniPlaceholders <https://github.com/MiniPlaceholders/MiniPlaceholders>`_
 ProtocolSidebar     An easy to use sidebar library for Paper/Spigot servers               `CatCoderr/ProtocolSidebar <https://github.com/CatCoderr/ProtocolSidebar>`_
 ScoreboardLibrary   A scoreboard library for Paper/Spigot servers                         `MegavexNetwork/scoreboard-library <https://github.com/MegavexNetwork/scoreboard-library>`_
 Triumph GUI         A library made to simplify the creation of inventory GUIs             `Triumph GUI <https://mf.mattstudios.me/triumph-gui/introduction>`_


### PR DESCRIPTION
Since the time MiniPlaceholders was included in this list, Krypton was abandoned and more platforms were supported. 
_This is probably the only and last pull request updating this description._