### PR TITLE
fix: URL of TriumphGUI

### DIFF
--- a/source/community-libraries.rst
+++ b/source/community-libraries.rst
@@ -52,5 +52,5 @@ LiteCommands        A annotation based command framework for Velocity, Bukkit, B
 MiniPlaceholders    A platform-agnostic MiniMessage Component-based Placeholders library  `MiniPlaceholders <https://github.com/MiniPlaceholders/MiniPlaceholders>`_
 ProtocolSidebar     An easy to use sidebar library for Paper/Spigot servers               `CatCoderr/ProtocolSidebar <https://github.com/CatCoderr/ProtocolSidebar>`_
 ScoreboardLibrary   A scoreboard library for Paper/Spigot servers                         `MegavexNetwork/scoreboard-library <https://github.com/MegavexNetwork/scoreboard-library>`_
-Triumph GUI         A library made to simplify the creation of inventory GUIs             `Triumph GUI <https://mf.mattstudios.me/triumph-gui/introduction>`_
+Triumph GUI         A library made to simplify the creation of inventory GUIs             `Triumph GUI <https://triumphteam.dev/docs/triumph-gui/introduction>`_
 =================== ===================================================================== ===================================================


### PR DESCRIPTION
Replaced the old url of TriumphGUI with the actual docs url.