### PR TITLE
Remove note about markdown mode returning to MiniMessage

### DIFF
--- a/source/minimessage/api.rst
+++ b/source/minimessage/api.rst
@@ -17,11 +17,6 @@ Getting Started
 
 MiniMessage exposes a simple API via the ``MiniMessage`` class.
 
-.. note::
-
-   Previously, a Markdown mode was available. This has been temporarily removed due to some issues
-   with the new 4.10.0 parser backend, but there are plans to re-add it once time permits.
-
 A standard instance of the serializer is available through the :java:`miniMessage()` method. This uses the default set of tags and is not in strict mode.
 
 Additional customization of MiniMessage is possible via the Builder_.


### PR DESCRIPTION
Realistically, Markdown mode is not going to be returning. There's been no demand for it and no motivation by any contributors to spend time reimplementing it.