### PR TITLE
[Feat] Add documentation about lang_or

### DIFF
--- a/source/minimessage/format.rst
+++ b/source/minimessage/format.rst
@@ -236,6 +236,26 @@ Examples
 .. image:: /minimessage/images/translatable_2.png
    :alt: The result of parsing ``<lang:commands.drop.success.single:'<red>1':'<blue>Stone'>!``, shown in-game in the Minecraft client's chat window in English
 
+Fallback
+========
+
+.. note::
+   
+   The fallback option is only available since Minecraft 1.19.4.
+
+Allows displaying minecraft messages using the player locale, or a fallback if no text is available
+
+Tag
+   :mm:`<lang_or:_key_:_fallback_:_value1_:_value2_...>`
+Aliases
+   ``tr_or``, ``translate_or``
+Arguments
+   * ``_key_``, the translation key
+   * ``_fallback_``, the fallback text to display
+   * ``_valueX_``, optional values that are used for placeholders in the key (they will end up in the ``with`` tag in the JSON)
+Examples
+   * :mm:`You should get a <lang_or:block.minecraft.diamond_block:'Dirt Block'>!`
+
 Insertion
 *********
 

--- a/source/minimessage/format.rst
+++ b/source/minimessage/format.rst
@@ -237,7 +237,7 @@ Examples
    :alt: The result of parsing ``<lang:commands.drop.success.single:'<red>1':'<blue>Stone'>!``, shown in-game in the Minecraft client's chat window in English
 
 Fallback
-========
+++++++++
 
 .. note::
    


### PR DESCRIPTION
Adds some documentation about the `<lang_or>` tag and its syntax.

I wasn't able to preview the changes as the instructions on the readme are either incomplete, outdated or something similar, as `pipenv run make livehtml` resulted in `sphinx-autobuild` not being recognized.